### PR TITLE
view state

### DIFF
--- a/assets/scripts/events.js
+++ b/assets/scripts/events.js
@@ -75,7 +75,6 @@ const onChangeColor = function () {
     .then(ui.changeColor(sqId, color))
 }
 
-
 module.exports = {
   onCreatePattern,
   onChangeColor,

--- a/assets/scripts/templates/pattern-display.handlebars
+++ b/assets/scripts/templates/pattern-display.handlebars
@@ -2,6 +2,7 @@
   <div id='{{pattern.id}}'>
     <div class="row" id='row1'>
       {{#each pattern.squares}}
-      <div class="col-xs-4 col-md-3 box" id="{{id}}sq"></div>
+      <div class="col-md-6 offset-md-3 box" id="{{id}}sq"></div>
       {{/each}}
+</div>
 </div>

--- a/assets/styles/index.scss
+++ b/assets/styles/index.scss
@@ -1,22 +1,7 @@
 $icon-font-path: '~bootstrap-sass/assets/fonts/bootstrap/';
+// $grid-columns: 18 !default;
 
 @import '~bootstrap-sass/assets/stylesheets/bootstrap';
-
-.box {
-  border: solid grey 4px;
-  height: 60px;
-  width: 60px;
-}
-
-.row {
-  padding-left: 380px;
-  padding-right: 380px;
-}
-
-.info {
-  font-size: 25px;
-  margin: 5px;
-}
 
 body {
   background-image: url('../../public/yarn.jpg');
@@ -41,4 +26,15 @@ h1 {
 
 h3 {
   font-weight: bold;
+}
+
+.box {
+  border: solid grey 4px;
+  height: 60px;
+  width: 5.5%;
+}
+
+.info {
+  font-size: 25px;
+  margin: 5px;
 }

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang=en>
     <head>
       <title>Knitting Patterns</title>
       <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -53,7 +53,7 @@
       </form>
       <button id='get-patterns' class='signed-in'>Show Patterns</button>
 
-      <div class='pattern'>
+      <div class='pattern container'>
       </div>
 
       <div class='patterns'>


### PR DESCRIPTION
- use bootstrap to center grid (offset by 3 columns, grid is 6 columns
wide)
- use bootstrap to make grid exactly 18 squares wide (each square 5.5%
of grid width, currently only works on screen over 990px)